### PR TITLE
Version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,9 +17,9 @@ builds:
       - GO111MODULE=on
     main: main.go
     ldflags: -s -w
-      -X github.com/borisputerka/kube-split-yaml/pkg/version.version={{.Version}}
-      -X github.com/borisputerka/kube-split-yaml/pkg/version.gitSHA={{.Commit}}
-      -X github.com/borisputerka/kube-split-yaml/pkg/version.buildTime={{.Date}}
+      -X github.com/borisputerka/kube-split-yaml/main.version={{.Version}}
+      -X github.com/borisputerka/kube-split-yaml/main.gitSHA={{.Commit}}
+      -X github.com/borisputerka/kube-split-yaml/main.buildTime={{.Date}}
       -extldflags "-static"
     flags: -tags netgo -installsuffix netgo
     binary: kube-split-yaml

--- a/main.go
+++ b/main.go
@@ -26,6 +26,11 @@ var (
 		"Input file with kube manifests.",
 	).String()
 
+	splitCommand = kingpin.Command(
+		"split",
+		"Splits one kubernetes yaml file with multiple resources into separated files",
+	)
+
 	versionCommand = kingpin.Command(
 		"version",
 		"Display version and git commit of this binary",

--- a/main.go
+++ b/main.go
@@ -25,30 +25,54 @@ var (
 		"input",
 		"Input file with kube manifests.",
 	).String()
+
+	versionCommand = kingpin.Command(
+		"version",
+		"Display version and git commit of this binary",
+	)
+
+	version   = ""
+	gitCommit = ""
 )
 
+// BuildInfo is a structure containing information about the build
+type BuildInfo struct {
+	// Version is the current semver.
+	Version string `json:"version,omitempty"`
+	// GitCommit is the git sha1.
+	GitCommit string `json:"git_commit,omitempty"`
+}
+
 func main() {
-	kingpin.Parse()
-	if *input != "" {
-		inputData, err = ioutil.ReadFile(*input)
+	switch kingpin.Parse() {
+	case versionCommand.FullCommand():
+		buildInfo := BuildInfo{
+			Version:   version,
+			GitCommit: gitCommit,
+		}
+		log.Printf("%#v", buildInfo)
+		return
+	default:
+		if *input != "" {
+			inputData, err = ioutil.ReadFile(*input)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+		} else {
+			scanner := bufio.NewScanner(os.Stdin)
+			if !scanner.Scan() {
+				log.Fatal("err: couldn't scan stdin")
+			}
+			for scanner.Scan() {
+				inputData = append(inputData, scanner.Text()...)
+				inputData = append(inputData, newLine...)
+			}
+		}
+
+		err = pkg.SplitYaml(string(inputData), *outputDir)
 		if err != nil {
 			log.Fatal(err)
 		}
-
-	} else {
-		scanner := bufio.NewScanner(os.Stdin)
-		if !scanner.Scan() {
-			log.Fatal("err: couldn't scan stdin")
-		}
-		for scanner.Scan() {
-			inputData = append(inputData, scanner.Text()...)
-			inputData = append(inputData, newLine...)
-		}
 	}
-
-	err = pkg.SplitYaml(string(inputData), *outputDir)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 }


### PR DESCRIPTION
This PR implements `version` command.

Implementation is inspired by how the `helm` project does the `helm version` command, but I think this is similar to other go projects.

The code now must specify also `split` command because after the first command `version` was implemented, `kingpin` requires to pass the second one to run splitting. So this is breaking change.

```bash
$ ./kube-split-yaml split --input kustomize-out.yaml --output-dir manifests

```

Validation of versioning was done locally using this build `$ go build -ldflags '-X main.version=v0.1.0 -X main.gitCommit=my-git-commit-sha'`. I expect that `.goreleaser` will somehow manage all this after the ldflags have correct paths to main package (but it needs to be checked by maintainer).


```bash
$ go build -ldflags '-X main.version=v0.1.0 -X main.gitCommit=my-git-commit-sha'
$ ./kube-split-yaml version
2021/02/12 13:15:12 main.BuildInfo{Version:"v0.1.0", GitCommit:"my-git-commit-sha"}

```